### PR TITLE
add __main__.py

### DIFF
--- a/gaps/__main__.py
+++ b/gaps/__main__.py
@@ -1,4 +1,10 @@
-from .cli import *
+try:
+    from gaps.cli import *
+except:
+    try:
+        from .cli import *
+    except:
+        from cli import *
 
 if __name__ == "__main__":
     cli()

--- a/gaps/__main__.py
+++ b/gaps/__main__.py
@@ -1,4 +1,4 @@
 from .cli import *
 
 if __name__ == "__main__":
-	cli()
+    cli()

--- a/gaps/__main__.py
+++ b/gaps/__main__.py
@@ -1,0 +1,4 @@
+from .cli import *
+
+if __name__ == '__main__':
+	cli();

--- a/gaps/__main__.py
+++ b/gaps/__main__.py
@@ -1,4 +1,4 @@
 from .cli import *
 
-if __name__ == '__main__':
-	cli();
+if __name__ == "__main__":
+	cli()


### PR DESCRIPTION
Since some one like to install packages in portable Python , there would not be a command like `gaps`.

Also currently they can not use the gaps as a module, if they use the command `.\python.exe -m gaps` , it will say:

`No module named gaps.__main__; 'gaps' is a package and cannot be directly executed`

add the `__main__.py` could let them use command as a module.

```SHELL

.\python.exe -m gaps [create|run] ...

```